### PR TITLE
Remove unnecessary glibc stuff from Dockerfile

### DIFF
--- a/pkg/Dockerfile.calico_upgrade
+++ b/pkg/Dockerfile.calico_upgrade
@@ -5,16 +5,5 @@ ADD dist/calico-upgrade ./calico-upgrade
 ENV CALICO_UPGRADE_CONTAINER=TRUE
 ENV PATH=$PATH:/
 
-# glibc and libltdl are needed by docker command line tool
-ENV GLIBC_VERSION 2.23-r3
-RUN apk add --no-cache libltdl
-RUN apk add --no-cache --update wget openssl ca-certificates && \
-  wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
-  wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \
-  wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk && \
-  apk add glibc-${GLIBC_VERSION}.apk glibc-bin-${GLIBC_VERSION}.apk && \
-  rm -f glibc-${GLIBC_VERSION}.apk glibc-bin-${GLIBC_VERSION}.apk && \
-  apk del openssl ca-certificates wget
-
 WORKDIR /root
 ENTRYPOINT ["/calico-upgrade"]


### PR DESCRIPTION
This isn't necessary since calico-upgrade doesn't call out to the Docker CLI like calicoctl does.