### PR TITLE
Add CanMigrate function to upgrade tool and other minor tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ VERSIONS_FILE?=$(CALICO_UPGRADE_DIR)../_data/versions.yml
 # Now use ?= to allow the versions derived from versions.yml to be
 # overriden (by the environment).
 CALICOCTL_VER?=master
-CALICOCTL_V2_VER?=v1.6.2
+CALICOCTL_V2_VER?=v1.6.x-series
 
 # Construct the calico/ctl names we'll use to download calicoctl and extract the
 # binaries.
@@ -217,13 +217,13 @@ dist/calicoctl:
 	-docker rm -f calicoctl
 
 dist/calicoctlv2:
-	-docker rm -f calicoctl
+	-docker rm -f calicoctlv2
 	docker pull $(CTL_CONTAINER_V2_NAME)
 	docker create --name calicoctlv2 $(CTL_CONTAINER_V2_NAME)
 	docker cp calicoctlv2:calicoctl dist/calicoctlv2 && \
 	  test -e dist/calicoctlv2 && \
 	  touch dist/calicoctlv2
-	-docker rm -f calicoctl
+	-docker rm -f calicoctlv2
 
 ## Run etcd as a container (calico-etcd)
 run-etcd: stop-etcd

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f08763ab1747c1c3b9a755d29c9352122de6a35ec169923084176f562c953485
-updated: 2017-12-19T15:58:47.965023972-08:00
+hash: 65dac3fdd637b0a12a7c58c6a5326c61e98e191d0a380db88d9d542bb6804458
+updated: 2018-01-03T00:13:01.713228Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -135,7 +135,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 54ac7fc147c8aa6b2fe93b41044a143b4a1e0bf7
+  version: 5894886f322904dfa21686ea45d9b7677c077076
   subpackages:
   - lib/apiconfig
   - lib/apis/v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/sirupsen/logrus
   version: ^1.0.3
 - package: github.com/projectcalico/libcalico-go
-  version: 54ac7fc147c8aa6b2fe93b41044a143b4a1e0bf7
+  version: 5894886f322904dfa21686ea45d9b7677c077076
 - package: github.com/coreos/etcd
   version: v3.2.7
 - package: github.com/spf13/pflag

--- a/pkg/commands/dryrun.go
+++ b/pkg/commands/dryrun.go
@@ -109,9 +109,20 @@ Description:
 }
 
 // validate performs the migration validation that is shared by both the dry-run
-// command and the start command. Returns true if there is data to migrate, false
-// otherwise.
+// command and the start command. Returns the migration data details if validation
+// succeeds, otherwise will os.Exit with a non-zero rc.
 func validate(m migrator.Interface, ch *cliHelper, output string, ignoreV3Data bool) *migrator.MigrationData {
+	// First check whether we can migrate from the current version.
+	err := m.CanMigrate()
+	if err != nil {
+		ch.Separator()
+		ch.Msg("Failed to validate v1 to v3 conversion.")
+		ch.Bullet(err.Error())
+		ch.NewLine()
+		os.Exit(1)
+		return nil
+	}
+
 	// Validate the conversion and that the destination is empty.
 	data, cerr := m.ValidateConversion()
 	clean, derr := m.IsDestinationEmpty()

--- a/pkg/constants/paths.go
+++ b/pkg/constants/paths.go
@@ -15,9 +15,10 @@
 package constants
 
 import (
-	"github.com/projectcalico/libcalico-go/lib/upgrade/migrator/clients"
 	"os"
 	"path/filepath"
+
+	"github.com/projectcalico/libcalico-go/lib/upgrade/migrator/clients"
 )
 
 const (


### PR DESCRIPTION
This PR includes two commits covering:
-  Version checks for migration
-  Improved error reporting when failing to prepare the reports directory