### PR TITLE
Add calico-upgrade FV test coverage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,11 @@ st: dist/calico-upgrade dist/calicoctl dist/calicoctlv2 run-etcd
 	# All of code under test is mounted into the container.
 	#   - This also provides access to calico-upgrade and the docker client
 	docker run --net=host --privileged \
+	           --uts=host \
+	           --pid=host \
 	           -e MY_IP=$(LOCAL_IP_ENV) \
 	           --rm -ti \
+                   -v /var/run/docker.sock:/var/run/docker.sock \
 	           -v $(SOURCE_DIR):/code \
 	           calico/test \
 	           sh -c 'nosetests $(ST_TO_RUN) -sv --nologcapture  --with-xunit --xunit-file="/code/nosetests.xml" --with-timer $(ST_OPTIONS)'
@@ -201,8 +204,11 @@ st: dist/calico-upgrade dist/calicoctl dist/calicoctlv2 run-etcd
 .PHONY: st
 testenv: dist/calico-upgrade dist/calicoctl dist/calicoctlv2 run-etcd
 	-docker run --net=host --privileged \
+	           --uts=host \
+	           --pid=host \
 	           --rm -ti \
 	           -v $(SOURCE_DIR):/code \
+                   -v /var/run/docker.sock:/var/run/docker.sock \
 	           --name=testenv \
 	           calico/test \
 	           sh

--- a/tests/st/calico_upgrade/test_calico_upgrade.py
+++ b/tests/st/calico_upgrade/test_calico_upgrade.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+
+import json
+import yaml
+from nose_parameterized import parameterized
+from nose.plugins.attrib import attr
+
+from tests.st.test_base import TestBase
+from tests.st.utils.utils import calicoctl, calicoctlv2, \
+    name, dump_etcdv2, get_value_etcdv2, get_value_etcdv3, \
+    calicoupgrade, wipe_etcdv2, get_ip, clean_calico_data
+from tests.st.utils.v1_data import data
+
+ETCD_SCHEME = os.environ.get("ETCD_SCHEME", "http")
+ETCD_CA = os.environ.get("ETCD_CA_CERT_FILE", "")
+ETCD_CERT = os.environ.get("ETCD_CERT_FILE", "")
+ETCD_KEY = os.environ.get("ETCD_KEY_FILE", "")
+ETCD_HOSTNAME_SSL = "etcd-authority-ssl"
+
+logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+CONVERT_ERROR_MSG = "ERROR: Error converting data, check output for details and resolve issues"
+
+
+class TestCalicoUpgrade(TestBase):
+
+    @parameterized.expand([
+        ("bgppeer_long_node_name", False),
+        ("bgppeer_dotted_asn", False),
+        ("hep_tame", False),
+        ("hep_mixed_ip", False),
+        ("hep_long_fields", False),
+        ("ippool_mixed", False),
+        ("ippool_v4_small", False),
+        ("ippool_v4_large", False),
+        ("node_long_name", False),
+        ("node_tame", False),
+        ("policy_long_name", False),
+        ("policy_big", False),
+        ("policy_tame", False),
+        ("profile_big", False),
+        ("profile_tame", False),
+        ("wep_lots_ips", False),
+        ("wep_similar_name_2", False),
+        ("do_not_track", False),
+        ("prednat_policy", False),
+    ])
+    @attr('slow')
+    def test_conversion(self, testname, fail_expected):
+        """
+        Test successful conversion of each resource, dry-run and start file validation.
+        etcdv2 Ready and etcdv3 datastoreReady flag validation.
+
+        Correctly converted data validated with calicoctlv3 get compared to
+        calicoctl convert manifest output.
+        """
+        testdata = data[testname]
+        report1 = "convertednames"
+
+        calicoctlv2("create", data=testdata)
+        logger.debug("INFO: dump of etcdv2:")
+        dump_etcdv2()
+
+        rcu = calicoupgrade("dry-run")
+        logger.debug("INFO: calico-upgrade dry-run should return 0.")
+        rcu.assert_no_error()
+
+        ready_output = get_value_etcdv2("/calico/v1/Ready")
+        assert ready_output == "true"
+
+        dr_report1 = _get_readlines(report1)
+        logger.debug(
+            "INFO: calico-upgrade dry-run %s output:\n%s" % (report1, dr_report1))
+
+        rcu = calicoupgrade("start")
+        logger.debug("INFO: calico-upgrade start should return 0.")
+        rcu.assert_no_error()
+
+        ready_output = get_value_etcdv2("/calico/v1/Ready")
+        assert ready_output == "false"
+
+        datastore_ready_rc = _get_ready_etcdv3()
+        assert datastore_ready_rc is False
+
+        st_report1 = _get_readlines(report1)
+        logger.debug(
+            "INFO: calico-upgrade start %s output:\n%s" % (report1, st_report1))
+
+        assert dr_report1 == st_report1, \
+            "INFO: calico-upgrade dry-run and start %s files are not equal" % report1
+
+        rcc = calicoctl("convert", data=testdata)
+        rcc.assert_no_error()
+
+        parsed_output = yaml.safe_load(rcc.output)
+        converted_data = clean_calico_data(parsed_output)
+        logger.debug("INFO: converted data to v3\n%s" % converted_data)
+        original_resource = rcc
+
+        rcc = calicoctl("get %s %s -o yaml" % (converted_data['kind'], name(converted_data)))
+        logger.debug("INFO: calicoctl (v3) get - after calico-upgrade start: \n%s" % rcc.output)
+
+        # Comparison here needs to be against cleaned versions of data to remove Creation Timestamp
+        logger.debug("Comparing 'get'ted output with original converted yaml")
+        cleaned_output = yaml.safe_dump(
+            clean_calico_data(
+                yaml.safe_load(rcc.output),
+                extra_keys_to_remove=['projectcalico.org/orchestrator', 'namespace']
+            )
+        )
+        original_resource.assert_data(cleaned_output)
+
+        rcu = calicoupgrade("complete")
+        logger.debug("INFO: calico-upgrade complete should return 0.")
+        rcu.assert_no_error()
+
+        ready_output = get_value_etcdv2("/calico/v1/Ready")
+        assert ready_output == "false"
+
+        datastore_ready_rc = _get_ready_etcdv3()
+        assert datastore_ready_rc is True
+
+    @parameterized.expand([
+        ("hep_bad_label", True, CONVERT_ERROR_MSG, "convertednames", "validationerrors"),
+        ("hep_label_too_long", True, CONVERT_ERROR_MSG, "convertednames", "validationerrors"),
+        ("hep_name_too_long", True, CONVERT_ERROR_MSG, "convertednames", "validationerrors"),
+        ("wep_bad_workload_id", True, CONVERT_ERROR_MSG, "convertednames", "conversionerrors"),
+        ("wep_similar_name", True, CONVERT_ERROR_MSG, "convertednames", "conversionerrors"),
+        ("profile_long_labels", True, CONVERT_ERROR_MSG, "validationerrors"),
+    ])
+    def test_conversion_failure(self, testname, fail_expected, error_text, report1, report2=None):
+        """
+        Test failed conversion with dry-run and start file validation.
+        etcdv2 Ready and etcdv3 datastoreReady flag validation.
+        """
+
+        testdata = data[testname]
+
+        calicoctlv2("create", data=testdata)
+        logger.debug("INFO: dump of etcdv2:")
+        dump_etcdv2()
+
+        rcu = calicoupgrade("dry-run")
+        logger.debug("INFO: calico-upgrade dry-run should return non-zero.")
+        rcu.assert_error(error_text)
+
+        ready_output = get_value_etcdv2("/calico/v1/Ready")
+        assert ready_output == "true"
+
+        dr_report1 = _get_readlines(report1)
+        logger.debug(
+            "INFO: calico-upgrade dry-run %s output:\n%s" % (report1, dr_report1))
+
+        if report2 is not None:
+            dr_report2 = _get_readlines(report2)
+            logger.debug(
+                "INFO: calico-upgrade dry-run %s output:\n%s" % (report2, dr_report2))
+
+        rcu = calicoupgrade("start")
+        logger.debug("INFO: calico-upgrade dry-run should return non-zero.")
+        rcu.assert_error(error_text)
+
+        ready_output = get_value_etcdv2("/calico/v1/Ready")
+        assert ready_output == "true"
+
+        st_report1 = _get_readlines(report1)
+        logger.debug(
+            "INFO: calico-upgrade start %s output:\n%s" % (report1, st_report1))
+
+        assert dr_report1 == st_report1, \
+            "INFO: calico-upgrade dry-run and start %s files are not equal" % report1
+
+        if report2 is not None:
+            st_report2 = _get_readlines(report2)
+            logger.debug(
+                "INFO: calico-upgrade dry-run %s output:\n%s" % (report2, st_report2))
+            assert dr_report2 == st_report2, \
+                "INFO: calico-upgrade dry-run and start %s files are not equal" % report2
+
+    @parameterized.expand([
+        ("ippool_mixed", False),
+        ("policy_long_name", False),
+        ("profile_big", False),
+    ])
+    @attr('slow')
+    def test_start_abort_ignore_v3_data(self, testname, fail_expected):
+        """
+        Test the abort command re-enables the v1 Ready flag.
+
+        calico-upgrade abort - aborts the upgrade process
+        by resuming Calico networking for the v2.x nodes.
+        """
+        testdata = data[testname]
+
+        calicoctlv2("create", data=testdata)
+        logger.debug("INFO: dump of etcdv2:")
+        dump_etcdv2()
+
+        rcu = calicoupgrade("start")
+        logger.debug("INFO: calico-upgrade start should return 0.")
+        rcu.assert_no_error()
+
+        ready_output = get_value_etcdv2("/calico/v1/Ready")
+        assert ready_output == "false"
+
+        datastore_ready_rc = _get_ready_etcdv3()
+        assert datastore_ready_rc is False
+
+        rcu = calicoupgrade("abort")
+        logger.debug("INFO: calico-upgrade abort should return 0.")
+        rcu.assert_no_error()
+
+        ready_output = get_value_etcdv2("/calico/v1/Ready")
+        assert ready_output == "true"
+
+        datastore_ready_rc = _get_ready_etcdv3()
+        assert datastore_ready_rc is False
+
+        rcu = calicoupgrade("start --ignore-v3-data")
+        logger.debug("INFO: calico-upgrade start should return 0.")
+        rcu.assert_no_error()
+
+        ready_output = get_value_etcdv2("/calico/v1/Ready")
+        assert ready_output == "false"
+
+        datastore_ready_rc = _get_ready_etcdv3()
+        assert datastore_ready_rc is False
+
+        rcu = calicoupgrade("complete")
+        logger.debug("INFO: calico-upgrade complete should return 0.")
+        rcu.assert_no_error()
+
+        ready_output = get_value_etcdv2("/calico/v1/Ready")
+        assert ready_output == "false"
+
+        datastore_ready_rc = _get_ready_etcdv3()
+        assert datastore_ready_rc is True
+
+
+@parameterized.expand([
+    "dry-run",
+    "start",
+])
+def test_empty_datastore(cmd):
+    """
+    Test dry-run and start when the etcdv2 datastore is empty.
+    """
+    wipe_etcdv2(get_ip())
+    dump_etcdv2()
+    rcu = calicoupgrade(cmd)
+    logger.debug("INFO: empty etcdv2 datastore: Expecting a non-zero"
+                 + "return code for calico-upgrade %s.", cmd)
+    rcu.assert_error()
+
+
+def _get_readlines(file_generated):
+    """
+    Get the readlines() of the file generated.
+    """
+    file_output = open("/code/calico-upgrade-report/"+file_generated, 'rU')
+    file_output_lines = file_output.readlines()
+    file_output.close()
+    return file_output_lines
+
+
+def _get_ready_etcdv3():
+    return_value = get_value_etcdv3(
+        "/calico/resources/v3/projectcalico.org/clusterinformations/default"
+        + " | grep -v /calico/resources/v3/projectcalico.org/clusterinformations/default")
+    logger.debug(
+        "INFO: value of /calico/resources/v3/projectcalico.org/clusterinformations/default\n%s"
+        % return_value)
+    decoded = json.loads(return_value)
+    logger.debug(
+        "INFO: etcdv3 datastoreReady flag is set to:\n%s" % decoded['spec']['datastoreReady'])
+    return decoded['spec']['datastoreReady']

--- a/tests/st/test_base.py
+++ b/tests/st/test_base.py
@@ -14,7 +14,8 @@
 import logging
 from unittest import TestCase
 
-from tests.st.utils.utils import (get_ip, wipe_etcd, calicoctl)
+from tests.st.utils.utils import (get_ip, wipe_etcdv2, wipe_etcdv3,
+                                  set_version_etcdv2, set_ready_etcdv2, get_value_etcdv2)
 
 HOST_IPV4 = get_ip()
 
@@ -32,10 +33,23 @@ class TestBase(TestCase):
         Clean up before every test.
         """
         self.ip = HOST_IPV4
-        self.wipe_etcd()
+        self.wipe_etcdv2()
+        self.wipe_etcdv3()
+        minimum_starting_state()
 
         # Log a newline to ensure that the first log appears on its own line.
         logger.info("")
 
-    def wipe_etcd(self):
-        wipe_etcd(self.ip)
+    def wipe_etcdv2(self):
+        wipe_etcdv2(self.ip)
+
+    def wipe_etcdv3(self):
+        wipe_etcdv3(self.ip)
+
+
+def minimum_starting_state():
+    logger.debug("INFO: Setting minimum starting state config for calicoctl v1")
+    set_version_etcdv2("v2.6.6-2-g0f0e2184")
+    set_ready_etcdv2("true")
+    ready_output = get_value_etcdv2("/calico/v1/Ready")
+    assert ready_output == "true"

--- a/tests/st/utils/v1_data.py
+++ b/tests/st/utils/v1_data.py
@@ -1,0 +1,477 @@
+# Copyright (c) 2017 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data = {}
+data['bgppeer_long_node_name'] = {
+    'apiVersion': 'v1',
+    'kind': 'bgpPeer',
+    'metadata': {
+        'scope': 'node',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75',
+        'peerIP': '192.168.255.255',
+    },
+    'spec': {
+        'asNumber': "4294967294",
+    },
+}
+data['bgppeer_dotted_asn'] = {
+    'apiVersion': 'v1',
+    'kind': 'bgpPeer',
+    'metadata': {
+        'scope': 'global',
+        'peerIP': '2006::2:1',
+    },
+    'spec': {
+        'asNumber': "1.10",
+    },
+}
+data['hep_tame'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {'type': 'production'},
+                 'name': 'eth0',
+                 'node': 'myhost'},
+    'spec': {'expectedIPs': ['192.168.0.1', '192.168.0.2'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_long_fields'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {
+        '8roper.evil/02.key_name.which.is-also_very.long...1234567890.p': 'frontendFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0',
+        'calico/k8s_ns': 'default',
+        'type': 'type-endFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '.123Im_a_LongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75'},
+    'spec': {'expectedIPs': ['fd00:1::321'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_label_too_long'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {
+        '8roper.evil/02.key_name.which.is-also_very.long...1234567890..proper.evil-02.key_name.which.is-also_very.long...1234567890..proper.evil-02.Key_Name.which.is-also_very.long...1234567890..proper.evil-02.key_name.which.is-also_very.long...1234567890..proper.evil-02.Key_name.which.is-also_very.long...1234567890..proper.evil-02.key_name.which.is-also_very.long...1234567890..proper.evil-02.key_Name.which.is-also_very.long...1234567890..proper.evil-02.key_name.which.is-also_very.long...1234567890..proper.evil-02.9': 'frontendFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0',
+        'calico/k8s_ns': 'default',
+        'type': 'type-endFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Her.Im_AlsoAVeryLongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75'},
+    'spec': {'expectedIPs': ['fd00:1::321'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_bad_label'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {
+        '8roper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/Key_Name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/Key_name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/key_Name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/9': 'frontendFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0',
+        'calico/k8s_ns': 'default',
+        'type': 'type-endFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Her.Im_AlsoAVeryLongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75'},
+    'spec': {'expectedIPs': ['fd00:1::321'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_name_too_long'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {
+        'calico/k8s_ns': 'default',
+        'type': 'type-endFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_AlsoAVeryLongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75'},
+    'spec': {'expectedIPs': ['fd00:1::321'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_mixed_ip'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {'type': 'production'},
+                 'name': 'eth0',
+                 'node': 'myotherhost'},
+    'spec': {'expectedIPs': ['192.168.0.1',
+                             '192.168.0.2',
+                             'fd00:ca:fe:1d:52:bb:e9:80'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['ippool_v4_small'] = {
+    'apiVersion': 'v1',
+    'kind': 'ipPool',
+    'metadata': {'cidr': '10.1.0.0/26'},
+    'spec': {'disabled': False,
+             'ipip': {'enabled': True, 'mode': 'cross-subnet'},
+             'nat-outgoing': True}
+}
+data['ippool_v4_large'] = {
+    'apiVersion': 'v1',
+    'kind': 'ipPool',
+    'metadata': {'cidr': '10.0.0.0/8'},
+    'spec': {'disabled': False,
+             'ipip': {'enabled': True, 'mode': 'always'},
+             'nat-outgoing': True}
+}
+data['ippool_mixed'] = {
+    'apiVersion': 'v1',
+    'kind': 'ipPool',
+    'metadata': {'cidr': '2006::/64'},
+    'spec': {'disabled': False,
+             'ipip': {'enabled': False, 'mode': 'always'},
+             'nat-outgoing': False}
+}
+data['node_long_name'] = {
+    'apiVersion': 'v1',
+    'kind': 'node',
+    'metadata': {
+        'name': '-Mary_had-A-Little___Lamb--Whose---Fleece-Was-White.As.Snow...She-Also-Had_an-Evil-NodeName_in_order_to.break.upgrade-code201600'},
+    'spec': {'bgp': {'asNumber': '7.20',
+                     'ipv4Address': '10.244.0.1/24',
+                     'ipv6Address': '2001:db8:85a3::8a2e:370:7334/120'}}
+}
+data['node_tame'] = {
+    'apiVersion': 'v1',
+    'kind': 'node',
+    'metadata': {'name': 'node-hostname'},
+    'spec': {'bgp': {'asNumber': 64512,
+                     'ipv4Address': '10.244.0.1/24',
+                     'ipv6Address': '2001:db8:85a3::8a2e:370:7334/120'}}
+}
+data['policy_tame'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {'name': 'allow-tcp-6379'},
+    'spec': {'egress': [{'action': 'allow'}],
+             'ingress': [{'action': 'allow',
+                          'destination': {'ports': [6379]},
+                          'protocol': 'tcp',
+                          'source': {'selector': "role == 'frontend'"}}],
+             'selector': "role == 'database'",
+             'types': ['ingress', 'egress']}
+}
+data['policy_long_name'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {
+        'name': '-Mary_had-A-Little___Lamb--Whose---Fleece-Was-White.As.Snow...She-Also-Had_an-Evil-PolicyName_in_order_to.break.upgrade-code2016'},
+    'spec': {'egress': [{'action': 'allow'}],
+             'ingress': [{'action': 'allow',
+                          'destination': {'ports': [6379]},
+                          'protocol': 'tcp',
+                          'source': {'nets': ['192.168.0.1/32']}}],
+             'selector': "role == 'database'",
+             'types': ['ingress', 'egress']}
+}
+data['profile_tame'] = {
+    'apiVersion': 'v1',
+    'kind': 'profile',
+    'metadata': {'labels': {'profile': 'profile1'}, 'name': 'profile1'},
+    'spec': {'egress': [{'action': 'allow'}],
+             'ingress': [{'action': 'deny',
+                          'source': {'nets': ['10.0.20.0/24']}},
+                         {'action': 'allow',
+                          'source': {'selector': "profile == 'profile1'"}}]}
+}
+data['profile_long_labels'] = {
+    'apiVersion': 'v1',
+    'kind': 'profile',
+    'metadata': {'labels': {
+        '8roper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/Key_Name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/Key_name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/key_Name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/9': 'frontendFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '-Mary_had-A-Little___Lamb--Whose---Fleece-Was-White.As.Snow...She-Also-Had_an-Evil-ProfileName_in_order_to.break.upgradeprofile1'},
+    'spec': {'egress': [{'action': 'allow'}],
+             'ingress': [{'action': 'deny',
+                          'source': {'nets': ['10.0.20.0/24',
+                                              '192.168.000.000/32',
+                                              '192.168.001.255/32',
+                                              '192.168.002.254/32',
+                                              '192.168.003.253/32',
+                                              '192.168.004.252/32',
+                                              '192.168.005.251/32',
+                                              '192.168.006.250/32',
+                                              '192.168.007.249/32',
+                                              '192.168.008.248/32',
+                                              '192.168.009.247/32',
+                                              '192.168.010.246/32',
+                                              '192.168.011.245/32',
+                                              '192.168.012.244/32',
+                                              '192.168.013.243/32',
+                                              '192.168.014.242/32',
+                                              '192.168.015.241/32',
+                                              '192.168.016.240/32',
+                                              '192.168.017.239/32',
+                                              '192.168.018.238/32',
+                                              '192.168.100.000/32',
+                                              '192.168.101.255/32',
+                                              '192.168.102.254/32',
+                                              '192.168.103.253/32',
+                                              '192.168.104.252/32',
+                                              '192.168.105.251/32',
+                                              '192.168.106.250/32',
+                                              '192.168.107.249/32',
+                                              '192.168.108.248/32',
+                                              '192.168.109.247/32',
+                                              '192.168.110.246/32',
+                                              '192.168.111.245/32',
+                                              '192.168.112.244/32',
+                                              '192.168.113.243/32',
+                                              '192.168.114.242/32',
+                                              '192.168.115.241/32',
+                                              '192.168.116.240/32',
+                                              '192.168.117.239/32',
+                                              '192.168.118.238/32',
+                                              '192.168.200.000/32',
+                                              '192.168.201.255/32',
+                                              '192.168.202.254/32',
+                                              '192.168.203.253/32',
+                                              '192.168.204.252/32',
+                                              '192.168.205.251/32',
+                                              '192.168.206.250/32',
+                                              '192.168.207.249/32',
+                                              '192.168.208.248/32',
+                                              '192.168.209.247/32',
+                                              '192.168.210.246/32',
+                                              '192.168.211.245/32',
+                                              '192.168.212.244/32',
+                                              '192.168.213.243/32',
+                                              '192.168.214.242/32',
+                                              '192.168.215.241/32',
+                                              '192.168.216.240/32',
+                                              '192.168.217.239/32',
+                                              '192.168.218.238/32',
+                                              '47.0.0.0/8']}},
+                         {'action': 'allow',
+                          'source': {'selector': "profile == 'profile1'"}}]}
+}
+data['policy_big'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {'annotations': {'aname': 'avalue'}, 'name': 'allow-tcp-6379'},
+    'spec': {'egress': [{'action': 'allow',
+                         'icmp': {'code': 25, 'type': 25},
+                         'protocol': 'icmp'}],
+             'ingress': [{'action': 'allow',
+                          'destination': {'ports': [6379]},
+                          'notProtocol': 'udplite',
+                          'protocol': 'tcp',
+                          'source': {
+                              'notSelector': "role != 'something' && thing in {'one', 'two'}",
+                              'selector': "role == 'frontend' && thing not in {'three', 'four'}"}},
+                         {'action': 'allow',
+                          'protocol': 'tcp',
+                          'source': {
+                              'notSelector': "role != 'something' && thing in {'one', 'two'}"}},
+                         {'action': 'deny',
+                          'destination': {'notPorts': [80],
+                                          'ports': [22, 443]},
+                          'protocol': 'tcp'},
+                         {'action': 'allow',
+                          'source': {'nets': ['172.18.18.200/32',
+                                              '172.18.19.0/24']}},
+                         {'action': 'allow',
+                          'source': {'net': '172.18.18.100/32'}},
+                         {'action': 'deny',
+                          'source': {'notNet': '172.19.19.100/32'}},
+                         {'action': 'deny',
+                          'source': {'notNets': ['172.18.0.0/16']}}],
+             'order': 1234,
+             'selector': "role == 'database' && !has(demo)",
+             'types': ['ingress', 'egress']}
+}
+data['profile_big'] = {
+    'apiVersion': 'v1',
+    'kind': 'profile',
+    'metadata': {'labels': {'profile': 'profile1'},
+                 'name': 'profile1',
+                 'tags': ['atag', 'btag']},
+    'spec': {'egress': [{'action': 'allow',
+                         'destination': {'notSelector': "profile == 'system'"}},
+                        {'action': 'allow',
+                         'source': {'selector': "something in {'a', 'b'}"}},
+                        {'action': 'allow',
+                         'destination': {'selector': "something not in {'a', 'b'}"}}],
+             'ingress': [{'action': 'deny',
+                          'destination': {'notPorts': [22, 443, 21, 8080],
+                                          'tag': 'atag'},
+                          'protocol': 'udp',
+                          'source': {'net': '172.20.0.0/16',
+                                     'notNet': '172.20.5.0/24',
+                                     'notTag': 'dtag',
+                                     'tag': 'ctag'}},
+                         {'action': 'deny',
+                          'destination': {'notPorts': [22, 443, 21, 8080],
+                                          'tag': 'atag'},
+                          'protocol': 'tcp',
+                          'source': {'nets': ['10.0.21.128/25'],
+                                     'notNets': ['10.0.20.0/24']}},
+                         {'action': 'deny',
+                          'protocol': 'tcp',
+                          'source': {'notNets': ['10.0.21.128/25']}},
+                         {'action': 'allow',
+                          'protocol': 'tcp',
+                          'source': {'ports': [1234, 4567, 489],
+                                     'selector': "profile != 'profile1' && has(role)"}}]}
+}
+data['wep_lots_ips'] = {
+    'apiVersion': 'v1',
+    'kind': 'workloadEndpoint',
+    'metadata': {'labels': {'app': 'frontend', 'calico/k8s_ns': 'default'},
+                 'name': 'eth0',
+                 'node': 'rack1-host1',
+                 'orchestrator': 'k8s',
+                 'workload': 'default.frontend-5gs43'},
+    'spec': {'interfaceName': 'cali0ef24ba',
+             'ipNetworks': ['192.168.000.000/32',
+                            '192.168.001.255/32',
+                            '192.168.002.254/32',
+                            '192.168.003.253/32',
+                            '192.168.004.252/32',
+                            '192.168.005.251/32',
+                            '192.168.006.250/32',
+                            '192.168.007.249/32',
+                            '192.168.008.248/32',
+                            '192.168.009.247/32',
+                            '192.168.010.246/32',
+                            '192.168.011.245/32',
+                            '192.168.012.244/32',
+                            '192.168.013.243/32',
+                            '192.168.014.242/32',
+                            '192.168.015.241/32',
+                            '192.168.016.240/32',
+                            '192.168.017.239/32',
+                            '192.168.018.238/32',
+                            '192.168.100.000/32',
+                            '192.168.101.255/32',
+                            '192.168.102.254/32',
+                            '192.168.103.253/32',
+                            '192.168.104.252/32',
+                            '192.168.105.251/32',
+                            '192.168.106.250/32',
+                            '192.168.107.249/32',
+                            '192.168.108.248/32',
+                            '192.168.109.247/32',
+                            '192.168.110.246/32',
+                            '192.168.111.245/32',
+                            '192.168.112.244/32',
+                            '192.168.113.243/32',
+                            '192.168.114.242/32',
+                            '192.168.115.241/32',
+                            '192.168.116.240/32',
+                            '192.168.117.239/32',
+                            '192.168.118.238/32',
+                            '192.168.200.000/32',
+                            '192.168.201.255/32',
+                            '192.168.202.254/32',
+                            '192.168.203.253/32',
+                            '192.168.204.252/32',
+                            '192.168.205.251/32',
+                            '192.168.206.250/32',
+                            '192.168.207.249/32',
+                            '192.168.208.248/32',
+                            '192.168.209.247/32',
+                            '192.168.210.246/32',
+                            '192.168.211.245/32',
+                            '192.168.212.244/32',
+                            '192.168.213.243/32',
+                            '192.168.214.242/32',
+                            '192.168.215.241/32',
+                            '192.168.216.240/32',
+                            '192.168.217.239/32',
+                            '192.168.218.238/32'],
+             'mac': 'ca:fe:1d:52:bb:e9',
+             'profiles': ['profile1']}
+}
+data['wep_similar_name'] = {
+    'apiVersion': 'v1',
+    'kind': 'workloadEndpoint',
+    'metadata': {'labels': {'app': 'frontend', 'calico/k8s_ns': 'default'},
+                 'name': 'eth0',
+                 'node': 'rack1-host1',
+                 'orchestrator': 'k8s',
+                 'workload': 'default/frontend-5gs43'},
+    'spec': {'interfaceName': 'cali0ef24ba',
+             'ipNetworks': ['192.168.0.0/32',
+                            '192.168.1.255/32',
+                            '192.168.2.254/32',
+                            '192.168.3.253/32',
+                            '192.168.4.252/32',
+                            '192.168.5.251/32',
+                            '192.168.6.250/32',
+                            '192.168.7.249/32',
+                            '192.168.8.248/32',
+                            '192.168.9.247/32',
+                            '192.168.10.246/32',
+                            '192.168.11.245/32',
+                            '192.168.12.244/32',
+                            '192.168.13.243/32',
+                            '192.168.14.242/32',
+                            '192.168.15.241/32',
+                            '192.168.16.240/32',
+                            '192.168.17.239/32',
+                            '192.168.18.238/32'],
+             'mac': 'fe:ed:ca:fe:00:00',
+             'profiles': ['profile1']}
+}
+data['wep_bad_workload_id'] = {
+    'apiVersion': 'v1',
+    'kind': 'workloadEndpoint',
+    'metadata': {'labels': {
+        'calico/k8s_ns': 'default'},
+        'name': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_AlsoAVeryLongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75',
+        'orchestrator': 'k8s',
+        'workload': 'default.-_.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My_AlsoAVeryLongWorkload-NameTryingToCatchOutUpgradeCode5'},
+    'spec': {'interfaceName': 'cali0ef24ba',
+             'ipNetworks': ['192.168.255.255/32', 'fd::1:40'],
+             'mac': 'ca:fe:1d:52:bb:e9',
+             'profiles': ['profile1']}
+}
+data['wep_similar_name_2'] = {
+    'apiVersion': 'v1',
+    'kind': 'workloadEndpoint',
+    'metadata': {'labels': {'app': 'frontend', 'calico/k8s_ns': 'default'},
+                 'name': 'eth0',
+                 'node': 'rack1-host1',
+                 'orchestrator': 'k8s',
+                 'workload': 'default.frontend.5gs43'},
+    'spec': {'interfaceName': 'cali0ef24ba',
+             'ipNetworks': ['fd00:ca:fe:1d:52:bb:e9:80'],
+             'mac': 'ca:fe:1d:52:bb:e9',
+             'profiles': ['profile1']}
+}
+data['do_not_track'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {'name': 'allow-tcp-555-donottrack'},
+    'spec': {'doNotTrack': True,
+             'ingress': [{'action': 'allow',
+                          'destination': {'ports': [555]},
+                          'protocol': 'tcp',
+                          'source': {'selector': "role == 'cache'"}}],
+             'order': 1230,
+             'selector': "role == 'database'",
+             'types': ['ingress']}
+}
+data['prednat_policy'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {'name': 'allow-cluster-internal-ingress'},
+    'spec': {'ingress': [{'action': 'allow',
+                          'source': {'nets': ['10.240.0.0/16',
+                                              '192.168.0.0/16']}}],
+             'order': 10,
+             'preDNAT': True,
+             'selector': 'has(host-endpoint)'}
+}


### PR DESCRIPTION
> XML: /code/nosetests.xml
[success] 5.21% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('profile_big', False): 16.6239s
[success] 5.20% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('policy_big', False): 16.5837s
[success] 5.19% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('wep_similar_name_2', False): 16.5705s
[success] 5.19% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('wep_lots_ips', False): 16.5661s
[success] 5.19% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('hep_tame', False): 16.5607s
[success] 5.19% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('ippool_mixed', False): 16.5549s
[success] 5.19% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('profile_tame', False): 16.5522s
[success] 5.18% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('hep_mixed_ip', False): 16.5385s
[success] 5.18% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('prednat_policy', False): 16.5266s
[success] 5.18% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('node_long_name', False): 16.5225s
[success] 5.18% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('node_tame', False): 16.5187s
[success] 5.18% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('hep_long_fields', False): 16.5183s
[success] 5.18% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('ippool_v4_large', False): 16.5150s
[success] 5.17% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('policy_tame', False): 16.5039s
[success] 5.17% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('bgppeer_long_node_name', False): 16.5000s
[success] 5.17% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('ippool_v4_small', False): 16.4913s
[success] 5.17% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('policy_long_name', False): 16.4850s
[success] 5.16% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('do_not_track', False): 16.4795s
[success] 5.16% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('bgppeer_dotted_asn', False): 16.4646s
[success] 0.25% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('hep_label_too_long', True, 'ERROR: Error converting data, check output for details and resolve issues'): 0.7908s
[success] 0.25% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('hep_name_too_long', True, 'ERROR: Error converting data, check output for details and resolve issues'): 0.7831s
[success] 0.24% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('profile_long_labels', True, 'ERROR: Error converting data, check output for details and resolve issues'): 0.7815s
[success] 0.24% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('wep_similar_name', True, 'ERROR: Error converting data, check output for details and resolve issues'): 0.7724s
[success] 0.24% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('wep_bad_workload_id', True, 'ERROR: Error converting data, check output for details and resolve issues'): 0.7652s
[success] 0.24% tests.st.calico_upgrade.test_calico_upgrade.test_conversion('hep_bad_label', True, 'ERROR: Error converting data, check output for details and resolve issues'): 0.7638s
[success] 0.06% tests.st.calico_upgrade.test_calico_upgrade.test_dry_run_0_dry_run: 0.1804s
[success] 0.05% tests.st.calico_upgrade.test_calico_upgrade.test_dry_run_1_start: 0.1648s

Ran 27 tests in 319.093s
