### PR TITLE
Automatic update of logrus to v1.0.4

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 547fb9d4dbebfc3557da8555d2f1f5dc513c464f90b7e73c0ecce8b25721164a
-updated: 2018-03-02T18:52:02.119178493Z
+hash: fb065d47814bdf37286428e927629fa58d094fcf84c46edf017ec64597ce44a5
+updated: 2018-03-19T14:53:59.834916486Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -190,7 +190,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 6fb6fce6f8b75884b92e1889c150403fc0872c5e
+  version: e4aa40a9169a88835b849a6efb71e05dc04b88f0
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -298,7 +298,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
-  version: 389dfa299845bcf399c16af89987e8775718ea48
+  version: 3c2a58f9923aeb5d27fa4d91249e45a1460ca3bd
   subpackages:
   - admissionregistration/v1alpha1
   - apps/v1beta1
@@ -325,7 +325,7 @@ imports:
   - storage/v1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 4972c8e335e32ab65ba45bde0a99c6544c8a8e4c
+  version: ab7fc865fb0881d161f37adef3e5a67b89a18d05
   subpackages:
   - pkg/api/equality
   - pkg/api/errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/projectcalico/calico-upgrade
 import:
 - package: github.com/sirupsen/logrus
-  version: ^1.0.3
+  version: v1.0.4
 - package: github.com/projectcalico/libcalico-go
   version: 16a16d0960511310db4772874de7650ab2967827
 - package: github.com/coreos/etcd


### PR DESCRIPTION
Pin logrus to v1.0.4 due to a breaking bug in v1.0.5.